### PR TITLE
Add uploadTranslationAndMarkAsDeprecated task

### DIFF
--- a/plugin/src/main/java/rejasupotaro/onesky/plugin/OneskyPlugin.kt
+++ b/plugin/src/main/java/rejasupotaro/onesky/plugin/OneskyPlugin.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Project
 import rejasupotaro.onesky.plugin.tasks.DownloadTranslationTask
 import rejasupotaro.onesky.plugin.tasks.ShowTranslationProgressTask
 import rejasupotaro.onesky.plugin.tasks.UploadTranslationTask
+import rejasupotaro.onesky.plugin.tasks.uploadTranslationAndMarkAsDeprecated
 
 class OneskyPlugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -13,6 +14,7 @@ class OneskyPlugin : Plugin<Project> {
             tasks.create("downloadTranslation", DownloadTranslationTask::class.java)
             tasks.create("uploadTranslation", UploadTranslationTask::class.java)
             tasks.create("showTranslationProgress", ShowTranslationProgressTask::class.java)
+            tasks.create("uploadTranslationAndMarkAsDeprecated", uploadTranslationAndMarkAsDeprecated::class.java)
         }
     }
 }

--- a/plugin/src/main/java/rejasupotaro/onesky/plugin/client/Onesky.kt
+++ b/plugin/src/main/java/rejasupotaro/onesky/plugin/client/Onesky.kt
@@ -21,9 +21,10 @@ class Onesky(val apiKey: String, val apiSecret: String, val projectId: Int) {
         return httpClient.get("$urlPrefix/projects/$projectId/translations", params)
     }
 
-    fun upload(translationFile: File): Result<String, FuelError> {
+    fun upload(translationFile: File, isKeepingAllStrings : Boolean = true): Result<String, FuelError> {
         val params = authParams()
         params.add("file_format" to "ANDROID_XML")
+        params.add("is_keeping_all_strings" to isKeepingAllStrings.toString())
 
         return httpClient.post("$urlPrefix/projects/$projectId/files", params, translationFile)
     }

--- a/plugin/src/main/java/rejasupotaro/onesky/plugin/tasks/UploadTranslationAndMarkAsDeprecatedTask.kt
+++ b/plugin/src/main/java/rejasupotaro/onesky/plugin/tasks/UploadTranslationAndMarkAsDeprecatedTask.kt
@@ -4,17 +4,17 @@ import com.github.kittinunf.result.Result
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
-open class UploadTranslationTask : OneskyTask() {
+open class uploadTranslationAndMarkAsDeprecated : OneskyTask() {
     init {
         group = "Translation"
-        description = "Upload the default translation file (values/strings.xml)"
+        description = "Upload the default translation file (values/strings.xml) and deprecate old translation"
     }
 
     @TaskAction
-    fun uploadTranslation() {
+    fun uploadTranslationAndMarkAsDeprecated() {
         val file = File("${project.projectDir.absolutePath}/src/main/res/values/strings.xml")
         print("Uploading ${file.absolutePath} ... ")
-        val result = oneskyClient.upload(file)
+        val result = oneskyClient.upload(file, isKeepingAllStrings = false)
         when (result) {
             is Result.Success -> {
                 println("Done!")

--- a/plugin/src/test/java/rejasupotaro/onesky/plugin/client/OneskyTest.kt
+++ b/plugin/src/test/java/rejasupotaro/onesky/plugin/client/OneskyTest.kt
@@ -75,7 +75,37 @@ class OneskyTest {
                 "api_key",
                 "dev_hash",
                 "timestamp",
-                "file_format")
+                "file_format",
+                "is_keeping_all_strings")
+        assertThat(paramsCaptor.firstValue.contains("is_keeping_all_strings" to "true"))
+    }
+
+    @Test
+    fun testUploadAndMarkAsDeprecated() {
+        val file = mock<File>()
+        val httpClient = mock<HttpClient> {
+            on {
+                post(any<String>(), any<List<Pair<String, String>>>(), any<File>())
+            }.doReturn(mock<Result<String, FuelError>> {})
+        }
+        onesky.httpClient = httpClient
+
+        onesky.upload(file, false)
+
+        val urlCaptor = argumentCaptor<String>()
+        val paramsCaptor = argumentCaptor<List<Pair<String, String>>>()
+        verify(httpClient).post(
+                urlCaptor.capture(),
+                paramsCaptor.capture(),
+                eq(file))
+        assertThat(urlCaptor.firstValue).isEqualTo("https://platform.api.onesky.io/1/projects/123456789/files")
+        assertThat(paramsCaptor.firstValue.map { it.first }).containsOnly(
+                "api_key",
+                "dev_hash",
+                "timestamp",
+                "file_format",
+                "is_keeping_all_strings")
+        assertThat(paramsCaptor.firstValue.contains("is_keeping_all_strings" to "false"))
     }
 
     @Test


### PR DESCRIPTION
- closes https://github.com/cookpad/onesky-gradle-plugin/issues/2

This PR add new task: `uploadTranslationAndMarkAsDeprecated` that is uploading translation with the option `is_keeping_all_strings` is set to false.

The default `uploadTranslation` has `is_keeping_all_strings` set to `true`.

The docs about `is_keeping_all_strings` behavior can be found in [onesky/api-documentation-platform](https://github.com/onesky/api-documentation-platform/blob/master/resources/file.md#upload---upload-a-file)
