### PR TITLE
Update AGP version - one sky gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.50'
+    ext.kotlin_version = '1.4.20'
     repositories {
         google()
         jcenter()
@@ -11,7 +11,7 @@ buildscript {
         maven { url 'https://repo.gradle.org/gradle/repo' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         classpath 'com.novoda:bintray-release:0.8.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compileOnly gradleApi()
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "com.github.kittinunf.fuel:fuel:1.10.0"
+    implementation "com.github.kittinunf.fuel:fuel:1.16.0"
     implementation "commons-codec:commons-codec:1.10"
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'com.jakewharton.fliptables:fliptables:1.0.2'


### PR DESCRIPTION
Ticket : https://github.com/cookpad/global-mobile-platform/issues/254
### Description 

This change updates the AGP version, along with kotlin so that the project opens and compiles in the latest version of Android Studio Dolphin.

I had to bump `fuel` version otherwise, the plugin was not compiling. I did not pick the latest version which comes from maven yet.


In the next change I will try to improve the documentation and will test the change with new git tag version.



### Checks

- all unit test pass ✅ 